### PR TITLE
feat: client-side item movement (server broadcasts, client renders)

### DIFF
--- a/src/client/itemMovementController.ts
+++ b/src/client/itemMovementController.ts
@@ -4,32 +4,92 @@ import { getRemotes } from "shared/remotes";
 import type { ItemMovementSnapshot } from "shared/types";
 
 interface ClientItemState extends ItemMovementSnapshot {
-	model?: Model;
+	model?: Model; // server-authoritative model reference if present
+	visual?: Model; // client-only visual clone used for interpolation
+	receivedAt: number; // server timestamp when we first received this id
 }
 
 const trackedItems = new Map<string, ClientItemState>();
+const UNRESOLVED_TIMEOUT = 5; // seconds before we drop unresolved item entries
 let initialized = false;
 
-function findTrackedModel(itemId: string): Model | undefined {
-	for (const descendant of Workspace.GetDescendants()) {
-		if (!descendant.IsA("Model")) {
-			continue;
+function createClientVisual(serverModel: Model): Model {
+	// Clone server model for client-only visuals and make parts non-collidable/anchored.
+	const visual = serverModel.Clone() as Model;
+	visual.Name = `${serverModel.Name}_clientVisual`;
+
+	for (const desc of visual.GetDescendants()) {
+		if (desc.IsA("BasePart")) {
+			const part = desc as BasePart;
+			part.CanCollide = false;
+			part.Anchored = true;
+			part.SetAttribute("ClientVisual", true);
 		}
 
-		const trackedItemId = descendant.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
-		if (typeIs(trackedItemId, "string") && trackedItemId === itemId) {
-			return descendant;
+		// Remove any runtime scripts to avoid unexpected behavior in the clone
+		if (desc.IsA("Script") || desc.IsA("LocalScript") || desc.IsA("ModuleScript")) {
+			desc.Destroy();
 		}
 	}
 
-	return undefined;
+	visual.Parent = Workspace;
+	return visual;
+}
+
+function indexExistingModels(): void {
+	for (const descendant of Workspace.GetDescendants()) {
+		if (!descendant.IsA("Model")) continue;
+		const trackedItemId = descendant.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+		if (typeIs(trackedItemId, "string") && trackedItemId.size() > 0) {
+			const state = trackedItems.get(trackedItemId);
+			if (state) {
+				state.model = descendant as Model;
+				if (!state.visual) {
+					state.visual = createClientVisual(state.model);
+				}
+			}
+		}
+	}
+}
+
+function onDescendantAdded(descendant: Instance): void {
+	if (!descendant.IsA("Model")) return;
+	const trackedItemId = descendant.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+	if (!typeIs(trackedItemId, "string") || trackedItemId.size() === 0) return;
+
+	const state = trackedItems.get(trackedItemId);
+	if (state) {
+		state.model = descendant as Model;
+		if (!state.visual) {
+			state.visual = createClientVisual(state.model);
+		}
+	}
+}
+
+function onDescendantRemoving(descendant: Instance): void {
+	if (!descendant.IsA("Model")) return;
+	const trackedItemId = descendant.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+	if (!typeIs(trackedItemId, "string") || trackedItemId.size() === 0) return;
+
+	const state = trackedItems.get(trackedItemId);
+	if (!state) return;
+
+	// Server model was removed; remove client visual and tracked state
+	if (state.visual) {
+		state.visual.Destroy();
+	}
+
+	trackedItems.delete(trackedItemId);
 }
 
 function updateTrackedItem(update: ItemMovementSnapshot): void {
 	const existing = trackedItems.get(update.itemId);
+	const now = Workspace.GetServerTimeNow();
 	trackedItems.set(update.itemId, {
 		...update,
 		model: existing?.model,
+		visual: existing?.visual,
+		receivedAt: existing?.receivedAt ?? now,
 	});
 }
 
@@ -37,22 +97,22 @@ function renderTrackedItems(): void {
 	const now = Workspace.GetServerTimeNow();
 
 	for (const [itemId, trackedItem] of trackedItems) {
-		const model = trackedItem.model ?? findTrackedModel(itemId);
-		if (!model) {
-			continue;
-		}
-
-		if (!model.Parent) {
+		// Cleanup unresolved entries after timeout
+		if (!trackedItem.model && now - trackedItem.receivedAt > UNRESOLVED_TIMEOUT) {
 			trackedItems.delete(itemId);
 			continue;
 		}
 
-		trackedItem.model = model;
-
 		const elapsed = math.max(0, now - trackedItem.timestamp);
 		const nextPosition = trackedItem.startPosition.add(trackedItem.velocity.mul(elapsed));
-		const currentPivot = model.GetPivot();
-		model.PivotTo(new CFrame(nextPosition).mul(currentPivot.Rotation));
+
+		if (trackedItem.visual) {
+			const currentPivot = trackedItem.visual.GetPivot();
+			trackedItem.visual.PivotTo(new CFrame(nextPosition).mul(currentPivot.Rotation));
+		} else if (trackedItem.model) {
+			// If we have the server model but no visual clone yet, create one now
+			trackedItem.visual = createClientVisual(trackedItem.model);
+		}
 	}
 }
 
@@ -62,6 +122,11 @@ export function initializeItemMovementController(): void {
 	}
 
 	initialized = true;
+
+	// Index existing models once and subscribe to changes rather than scanning every frame
+	indexExistingModels();
+	Workspace.DescendantAdded.Connect(onDescendantAdded);
+	Workspace.DescendantRemoving.Connect(onDescendantRemoving);
 
 	getRemotes().ItemMovement.OnClientEvent.Connect((updates: ItemMovementSnapshot[]) => {
 		for (const update of updates) {

--- a/src/client/itemMovementController.ts
+++ b/src/client/itemMovementController.ts
@@ -1,0 +1,75 @@
+import { RunService, Workspace } from "@rbxts/services";
+import { ITEM_MOVEMENT_ID_ATTRIBUTE } from "shared/constants";
+import { getRemotes } from "shared/remotes";
+import type { ItemMovementSnapshot } from "shared/types";
+
+interface ClientItemState extends ItemMovementSnapshot {
+	model?: Model;
+}
+
+const trackedItems = new Map<string, ClientItemState>();
+let initialized = false;
+
+function findTrackedModel(itemId: string): Model | undefined {
+	for (const descendant of Workspace.GetDescendants()) {
+		if (!descendant.IsA("Model")) {
+			continue;
+		}
+
+		const trackedItemId = descendant.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+		if (typeIs(trackedItemId, "string") && trackedItemId === itemId) {
+			return descendant;
+		}
+	}
+
+	return undefined;
+}
+
+function updateTrackedItem(update: ItemMovementSnapshot): void {
+	const existing = trackedItems.get(update.itemId);
+	trackedItems.set(update.itemId, {
+		...update,
+		model: existing?.model,
+	});
+}
+
+function renderTrackedItems(): void {
+	const now = Workspace.GetServerTimeNow();
+
+	for (const [itemId, trackedItem] of trackedItems) {
+		const model = trackedItem.model ?? findTrackedModel(itemId);
+		if (!model) {
+			continue;
+		}
+
+		if (!model.Parent) {
+			trackedItems.delete(itemId);
+			continue;
+		}
+
+		trackedItem.model = model;
+
+		const elapsed = math.max(0, now - trackedItem.timestamp);
+		const nextPosition = trackedItem.startPosition.add(trackedItem.velocity.mul(elapsed));
+		const currentPivot = model.GetPivot();
+		model.PivotTo(new CFrame(nextPosition).mul(currentPivot.Rotation));
+	}
+}
+
+export function initializeItemMovementController(): void {
+	if (initialized) {
+		return;
+	}
+
+	initialized = true;
+
+	getRemotes().ItemMovement.OnClientEvent.Connect((updates: ItemMovementSnapshot[]) => {
+		for (const update of updates) {
+			updateTrackedItem(update);
+		}
+	});
+
+	RunService.PreRender.Connect(() => {
+		renderTrackedItems();
+	});
+}

--- a/src/client/main.client.tsx
+++ b/src/client/main.client.tsx
@@ -2,12 +2,15 @@ import { Players } from "@rbxts/services";
 import { getRemotes } from "shared/remotes";
 import React, { StrictMode, useEffect, useState } from "@rbxts/react";
 import { createPortal, createRoot } from "@rbxts/react-roblox";
+import { initializeItemMovementController } from "./itemMovementController";
 import { GameUI } from "./ui/components/GameUI";
 import { placementController } from "./placementController";
 
 const player = Players.LocalPlayer;
 const playerGui = player.WaitForChild("PlayerGui") as PlayerGui;
 const remotes = getRemotes();
+
+initializeItemMovementController();
 
 function getInitialBalance(): number {
 	const leaderstats = player.FindFirstChild("leaderstats");

--- a/src/server/models/conveyors/conveyorClass.ts
+++ b/src/server/models/conveyors/conveyorClass.ts
@@ -64,7 +64,19 @@ export abstract class ConveyorClass {
 					const itemModel = bodyPart.FindFirstAncestorOfClass("Model");
 
 					if (itemModel) {
-						setTrackedItemVelocity(itemModel, conveyorVelocity);
+						// Only track product models. Skip humanoids/character models and anything
+						// without a ProductValue attribute so we don't accidentally track players.
+						const hasHumanoid =
+							itemModel.FindFirstChildWhichIsA("Humanoid") !== undefined ||
+							itemModel.FindFirstChild("HumanoidRootPart") !== undefined;
+						const productValue = itemModel.GetAttribute("ProductValue");
+
+						if (!hasHumanoid && typeIs(productValue, "number")) {
+							setTrackedItemVelocity(itemModel, conveyorVelocity);
+						} else {
+							// Fallback: apply velocity to the touching part only
+							bodyPart.AssemblyLinearVelocity = conveyorVelocity;
+						}
 					} else {
 						bodyPart.AssemblyLinearVelocity = conveyorVelocity;
 					}

--- a/src/server/models/conveyors/conveyorClass.ts
+++ b/src/server/models/conveyors/conveyorClass.ts
@@ -1,4 +1,5 @@
 import { spawnTemplateModel } from "server/models/spawnUtils";
+import { setTrackedItemVelocity } from "server/services/itemMovementService";
 import { logger } from "server/utils/logger";
 import { CONVEYOR_CONFIG } from "shared/constants";
 
@@ -59,7 +60,14 @@ export abstract class ConveyorClass {
 				// Transport the item along the conveyor
 				while (this.model.Parent && bodyPart.Parent && this.transportedItems.has(part)) {
 					const moveDirection = conveyorSurface.CFrame.LookVector;
-					bodyPart.AssemblyLinearVelocity = moveDirection.mul(this.getSpeed());
+					const conveyorVelocity = moveDirection.mul(this.getSpeed());
+					const itemModel = bodyPart.FindFirstAncestorOfClass("Model");
+
+					if (itemModel) {
+						setTrackedItemVelocity(itemModel, conveyorVelocity);
+					} else {
+						bodyPart.AssemblyLinearVelocity = conveyorVelocity;
+					}
 
 					task.wait(CONVEYOR_CONFIG.updateInterval); // ~60 FPS
 				}

--- a/src/server/models/products/woodCube.ts
+++ b/src/server/models/products/woodCube.ts
@@ -1,5 +1,6 @@
 import { Workspace } from "@rbxts/services";
 import type { Product } from "server/models/products/Products";
+import { registerTrackedItem } from "server/services/itemMovementService";
 import { PRODUCT_CONFIG } from "shared/constants";
 
 export class WoodCube implements Product {
@@ -24,6 +25,8 @@ export class WoodCube implements Product {
 		woodModel.PrimaryPart = part;
 		woodModel.PivotTo(new CFrame(position));
 		woodModel.Parent = Workspace;
+		part.SetNetworkOwner(undefined);
+		registerTrackedItem(woodModel);
 
 		task.delay(PRODUCT_CONFIG.woodCube.lifetime, () => {
 			woodModel.Destroy();

--- a/src/server/services/itemMovementService.ts
+++ b/src/server/services/itemMovementService.ts
@@ -3,6 +3,9 @@ import { ITEM_MOVEMENT_CONFIG, ITEM_MOVEMENT_ID_ATTRIBUTE } from "shared/constan
 import { getRemotes } from "shared/remotes";
 import type { ItemMovementSnapshot } from "shared/types";
 
+// Cache remotes once to avoid repeated lookups in the sync loop
+const remotes = getRemotes();
+
 interface TrackedItemRecord {
 	model: Model;
 	lastVelocity: Vector3;
@@ -13,9 +16,16 @@ let nextItemId = 0;
 let syncLoopStarted = false;
 
 function getPrimaryPart(itemModel: Model): BasePart | undefined {
-	const primaryPart = itemModel.PrimaryPart ?? (itemModel.FindFirstChildWhichIsA("BasePart") as BasePart | undefined);
-	if (primaryPart && itemModel.PrimaryPart !== primaryPart) {
-		itemModel.PrimaryPart = primaryPart;
+	// Require an explicit PrimaryPart. Avoid mutating models or picking arbitrary parts
+	// via FindFirstChildWhichIsA — product models should set PrimaryPart at creation.
+	const primaryPart = itemModel.PrimaryPart as BasePart | undefined;
+	if (!primaryPart) {
+		return undefined;
+	}
+
+	// Guard against mis-parenting
+	if (!primaryPart.IsDescendantOf(itemModel)) {
+		return undefined;
 	}
 
 	return primaryPart;
@@ -89,7 +99,7 @@ function broadcastSnapshots(snapshots: ItemMovementSnapshot[]): void {
 		return;
 	}
 
-	getRemotes().ItemMovement.FireAllClients(snapshots);
+	remotes.ItemMovement.FireAllClients(snapshots);
 }
 
 function startItemMovementSyncLoop(): void {

--- a/src/server/services/itemMovementService.ts
+++ b/src/server/services/itemMovementService.ts
@@ -1,0 +1,176 @@
+import { Workspace } from "@rbxts/services";
+import { ITEM_MOVEMENT_CONFIG, ITEM_MOVEMENT_ID_ATTRIBUTE } from "shared/constants";
+import { getRemotes } from "shared/remotes";
+import type { ItemMovementSnapshot } from "shared/types";
+
+interface TrackedItemRecord {
+	model: Model;
+	lastVelocity: Vector3;
+}
+
+const trackedItems = new Map<string, TrackedItemRecord>();
+let nextItemId = 0;
+let syncLoopStarted = false;
+
+function getPrimaryPart(itemModel: Model): BasePart | undefined {
+	const primaryPart = itemModel.PrimaryPart ?? (itemModel.FindFirstChildWhichIsA("BasePart") as BasePart | undefined);
+	if (primaryPart && itemModel.PrimaryPart !== primaryPart) {
+		itemModel.PrimaryPart = primaryPart;
+	}
+
+	return primaryPart;
+}
+
+function createItemId(): string {
+	nextItemId += 1;
+	return `item_${nextItemId}`;
+}
+
+function getOrAssignItemId(itemModel: Model): string {
+	const existingItemId = itemModel.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+	if (typeIs(existingItemId, "string") && existingItemId.size() > 0) {
+		return existingItemId;
+	}
+
+	const itemId = createItemId();
+	itemModel.SetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE, itemId);
+
+	const primaryPart = getPrimaryPart(itemModel);
+	if (primaryPart) {
+		primaryPart.SetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE, itemId);
+	}
+
+	return itemId;
+}
+
+function ensureTrackedItem(itemModel: Model): string {
+	const itemId = getOrAssignItemId(itemModel);
+	const existing = trackedItems.get(itemId);
+	if (existing) {
+		existing.model = itemModel;
+		return itemId;
+	}
+
+	trackedItems.set(itemId, {
+		model: itemModel,
+		lastVelocity: new Vector3(0, 0, 0),
+	});
+
+	itemModel.Destroying.Connect(() => {
+		unregisterTrackedItem(itemModel);
+	});
+
+	startItemMovementSyncLoop();
+	return itemId;
+}
+
+function createSnapshot(itemId: string, itemModel: Model): ItemMovementSnapshot | undefined {
+	if (!itemModel.Parent) {
+		return undefined;
+	}
+
+	const primaryPart = getPrimaryPart(itemModel);
+	if (!primaryPart) {
+		return undefined;
+	}
+
+	primaryPart.SetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE, itemId);
+
+	return {
+		itemId,
+		startPosition: primaryPart.Position,
+		velocity: primaryPart.AssemblyLinearVelocity,
+		timestamp: Workspace.GetServerTimeNow(),
+	};
+}
+
+function broadcastSnapshots(snapshots: ItemMovementSnapshot[]): void {
+	if (snapshots.size() === 0) {
+		return;
+	}
+
+	getRemotes().ItemMovement.FireAllClients(snapshots);
+}
+
+function startItemMovementSyncLoop(): void {
+	if (syncLoopStarted) {
+		return;
+	}
+
+	syncLoopStarted = true;
+
+	task.spawn(() => {
+		while (true) {
+			task.wait(ITEM_MOVEMENT_CONFIG.syncInterval);
+
+			if (trackedItems.size() === 0) {
+				continue;
+			}
+
+			const snapshots = new Array<ItemMovementSnapshot>();
+			for (const [itemId, trackedItem] of trackedItems) {
+				const snapshot = createSnapshot(itemId, trackedItem.model);
+				if (!snapshot) {
+					trackedItems.delete(itemId);
+					continue;
+				}
+
+				trackedItem.lastVelocity = snapshot.velocity;
+				snapshots.push(snapshot);
+			}
+
+			broadcastSnapshots(snapshots);
+		}
+	});
+}
+
+export function registerTrackedItem(itemModel: Model): string {
+	const itemId = ensureTrackedItem(itemModel);
+	syncTrackedItem(itemModel);
+	return itemId;
+}
+
+export function syncTrackedItem(itemModel: Model): void {
+	const itemId = ensureTrackedItem(itemModel);
+	const trackedItem = trackedItems.get(itemId);
+	if (!trackedItem) {
+		return;
+	}
+
+	const snapshot = createSnapshot(itemId, trackedItem.model);
+	if (!snapshot) {
+		trackedItems.delete(itemId);
+		return;
+	}
+
+	trackedItem.lastVelocity = snapshot.velocity;
+	broadcastSnapshots([snapshot]);
+}
+
+export function setTrackedItemVelocity(itemModel: Model, velocity: Vector3): void {
+	const primaryPart = getPrimaryPart(itemModel);
+	if (!primaryPart) {
+		return;
+	}
+
+	primaryPart.AssemblyLinearVelocity = velocity;
+
+	const itemId = ensureTrackedItem(itemModel);
+	const trackedItem = trackedItems.get(itemId);
+	if (!trackedItem) {
+		return;
+	}
+
+	if (trackedItem.lastVelocity.sub(velocity).Magnitude > 0.01) {
+		syncTrackedItem(itemModel);
+	}
+}
+
+export function unregisterTrackedItem(itemModel: Model): void {
+	const existingItemId = itemModel.GetAttribute(ITEM_MOVEMENT_ID_ATTRIBUTE);
+	if (!typeIs(existingItemId, "string") || existingItemId.size() === 0) {
+		return;
+	}
+
+	trackedItems.delete(existingItemId);
+}

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -30,6 +30,12 @@ export const PRODUCT_CONFIG = {
 	},
 } as const;
 
+export const ITEM_MOVEMENT_ID_ATTRIBUTE = "ItemMovementId";
+
+export const ITEM_MOVEMENT_CONFIG = {
+	syncInterval: 0.1,
+} as const;
+
 // Conveyor configuration
 export const CONVEYOR_CONFIG = {
 	baseSpeed: 1,

--- a/src/shared/remotes.ts
+++ b/src/shared/remotes.ts
@@ -1,5 +1,5 @@
 import { ReplicatedStorage } from "@rbxts/services";
-import { PlaceRequest, PlaceResponse } from "./types";
+import { ItemMovementSnapshot, PlaceRequest, PlaceResponse } from "./types";
 
 type TypedRemoteEvent<TArgs extends defined[] = []> = RemoteEvent & {
 	FireServer: (...args: TArgs) => void;
@@ -16,6 +16,7 @@ export interface Remotes {
 	UpdateMultiplier: TypedRemoteEvent<[newMultiplier: number]>;
 	PlaceRequest: TypedRemoteEvent<[request: PlaceRequest]>;
 	PlaceResponse: TypedRemoteEvent<[response: PlaceResponse]>;
+	ItemMovement: TypedRemoteEvent<[updates: ItemMovementSnapshot[]]>;
 }
 
 export function getRemotes(): Remotes {
@@ -45,5 +46,6 @@ export function getRemotes(): Remotes {
 		UpdateMultiplier: ensureRemote("UpdateMultiplier"),
 		PlaceRequest: ensureRemote("PlaceRequest"),
 		PlaceResponse: ensureRemote("PlaceResponse"),
+		ItemMovement: ensureRemote("ItemMovement"),
 	};
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -69,6 +69,13 @@ export interface PlaceResponse {
 	reason?: string;
 }
 
+export interface ItemMovementSnapshot {
+	itemId: string;
+	startPosition: Vector3;
+	velocity: Vector3;
+	timestamp: number;
+}
+
 export const PLOT_SIZE = 50; // 50x50 cells per plot
 export const PLOT_SIZE_STUDS = 50; // actual plot size in studs (50x1x50)
 export const GRID_CELL_SIZE = PLOT_SIZE_STUDS / PLOT_SIZE; // 1 stud per cell


### PR DESCRIPTION
Summary:
- Move item rendering to the client: server broadcasts item snapshots (itemId, startPosition, velocity, timestamp) and clients locally animate via RunService.PreRender.

What changed:
- Added ItemMovement remote and ItemMovementSnapshot type in shared/ (remotes.ts, types.ts)
- Server itemMovementService to assign item IDs, track items, and broadcast snapshots
- WoodCube registers spawned items for tracking; conveyors call into the service to set tracked velocities
- Client itemMovementController interpolates items locally using server snapshots

Why:
- Smoother visuals and reduced server-side per-frame physics; better scalability for many items/clients.

Verification:
- Build: bun run build (rbxtsc) should succeed.
- Manual: spawn miner + conveyor + sell zone in Studio, test with multiple clients and confirm smooth item motion and sell behavior.

Notes & follow-ups:
- Server still sets AssemblyLinearVelocity for non-tracked parts; tracked items use snapshots and timestamps.
- Consider batching/frequency tuning for large numbers of items and sending destruction events to avoid orphaned client models.
